### PR TITLE
Use GitHubActionsLogger when building docs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ runs:
     - name: Install GitHubActions.jl in global environment
       run: |
         using Pkg
+        Pkg.activate("docs-logger-env"; shared=true)
         Pkg.add(name="GitHubActions", version="0.1")
       shell: julia --color=yes {0}
     - run: |
@@ -34,6 +35,7 @@ runs:
     - run: |
         # The Julia command that will be executed
         julia_cmd=( julia --color=yes --code-coverage --project=docs/ -e '
+            pushfirst!(LOAD_PATH, "@docs-logger-env") # access GitHubActions.jl
             using Logging: global_logger
             using GitHubActions: GitHubActionsLogger
             global_logger(GitHubActionsLogger())

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
       shell: bash
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --color=yes --project=docs/ -e '
+        julia_cmd=( julia --color=yes --code-coverage --project=docs/ -e '
             using Logging: global_logger
             using GitHubActions: GitHubActionsLogger
             global_logger(GitHubActionsLogger())

--- a/action.yml
+++ b/action.yml
@@ -35,10 +35,12 @@ runs:
     - run: |
         # The Julia command that will be executed
         julia_cmd=( julia --color=yes --code-coverage --project=docs/ -e '
-            push!(LOAD_PATH, "@docs-logger-env") # access GitHubActions.jl
-            import Logging, GitHubActions
-            Logging.global_logger(GitHubActions.GitHubActionsLogger())
-            pop!(LOAD_PATH)
+            @eval Module() begin
+                push!(LOAD_PATH, "@docs-logger-env") # access GitHubActions.jl
+                import Logging, GitHubActions
+                Logging.global_logger(GitHubActions.GitHubActionsLogger())
+                pop!(LOAD_PATH)
+            end
             include("docs/make.jl")' )
 
         # Add the prefix in front of the command if there is one

--- a/action.yml
+++ b/action.yml
@@ -35,10 +35,10 @@ runs:
     - run: |
         # The Julia command that will be executed
         julia_cmd=( julia --color=yes --code-coverage --project=docs/ -e '
-            pushfirst!(LOAD_PATH, "@docs-logger-env") # access GitHubActions.jl
-            using Logging: global_logger
-            using GitHubActions: GitHubActionsLogger
-            global_logger(GitHubActionsLogger())
+            push!(LOAD_PATH, "@docs-logger-env") # access GitHubActions.jl
+            import Logging, GitHubActions
+            Logging.global_logger(GitHubActions.GitHubActionsLogger())
+            pop!(LOAD_PATH)
             include("docs/make.jl")' )
 
         # Add the prefix in front of the command if there is one

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install GitHubActions.jl in global environment
+    - name: Install GitHubActions.jl in its own (shared) environment
       run: |
         using Pkg
         Pkg.activate("docs-logger-env"; shared=true)

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install GitHubActions.jl in global environment
       run: |
         using Pkg
-        Pkg.add(name="GitHubActionsLogger", version="0.1")
+        Pkg.add(name="GitHubActions", version="0.1")
       shell: julia --color=yes {0}
     - run: |
         # The Julia command that will be executed

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install GitHubActions.jl in global environment
       run: |
         using Pkg
-        Pkg.add("GitHubActionsLogger", version="0.1")
+        Pkg.add(name="GitHubActionsLogger", version="0.1")
       shell: julia --color=yes {0}
     - run: |
         # The Julia command that will be executed

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
       shell: bash
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --color=yes --code-coverage --project=docs/ -e '
+        julia_cmd=( julia --color=yes --project=docs/ -e '
             @eval Module() begin
                 push!(LOAD_PATH, "@docs-logger-env") # access GitHubActions.jl
                 import Logging, GitHubActions

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
       run: |
         using Pkg
         Pkg.activate("docs-logger-env"; shared=true)
-        Pkg.add(name="GitHubActions", version="0.1")
+        Pkg.add(Pkg.PackageSpec(name="GitHubActions", version="0.1"))
       shell: julia --color=yes {0}
     - run: |
         # The Julia command that will be executed

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Install GitHubActions.jl in global environment
+      run: |
+        using Pkg
+        Pkg.add("GitHubActionsLogger", version="0.1")
+      shell: julia --color=yes {0}
     - run: |
         # The Julia command that will be executed
         julia_cmd=( julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()' )
@@ -26,10 +31,13 @@ runs:
         # Run the Julia command
         "${julia_cmd[@]}"
       shell: bash
-
     - run: |
         # The Julia command that will be executed
-        julia_cmd=( julia --color=yes --project=docs/ docs/make.jl )
+        julia_cmd=( julia --color=yes --project=docs/ -e '
+            using Logging: global_logger
+            using GitHubActions: GitHubActionsLogger
+            global_logger(GitHubActionsLogger())
+            include("docs/make.jl")' )
 
         # Add the prefix in front of the command if there is one
         prefix="${{ inputs.prefix }}"


### PR DESCRIPTION
This lets us get inline annotations for doctest errors:

<img width="1175" alt="Screenshot 2021-08-28 at 15 01 50" src="https://user-images.githubusercontent.com/5846501/131221106-33d0c074-02cc-48d3-ba40-66f10d43bd4f.png">

(well, that requires a small fix in [Documenter](https://github.com/JuliaDocs/Documenter.jl/pull/1687) and in [GitHubActions.jl](https://github.com/julia-actions/GitHubActions.jl/pull/15) as well).

Tested here: https://github.com/ericphanson/VisualStringDistances.jl/runs/3450753006?check_suite_focus=true

Not sure if this should behind a setting (or opt-out), and if the use of the global env is the right way to go. (One way to opt-out though is to just set whatever logger you want yourself inside `docs/make.jl` -- so I think it kind of makes sense that the default should be a GitHubActionsLogger rather than a ConsoleLogger).