### PR TITLE
Make `Pkg.develop` step optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,11 @@ inputs:
     description: 'Value inserted in front of the julia command, e.g. for running xvfb-run julia [...]'
     default: ''
     required: false
-
+  install_package:
+    description: 'Whether or not to install the package with `Pkg.develop` into the `docs` environment'
+    default: true
+    require: false
+    
 runs:
   using: 'composite'
   steps:
@@ -32,6 +36,7 @@ runs:
         # Run the Julia command
         "${julia_cmd[@]}"
       shell: bash
+      if: ${{ install_package }}
     - run: |
         # The Julia command that will be executed
         julia_cmd=( julia --color=yes --project=docs/ -e '


### PR DESCRIPTION
It can be useful to install it yourself, for example if it is in a subdirectory (but `docs` is still top-level)