### PR TITLE
Mention how to set terminal width

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,14 @@ In some packages, you may want to install the package yourself into the docs env
         with:
           install-package: false
 ```
+
+### Setting terminal width
+
+For some doctests, the default terminal width of GitHub Runners is too narrow.
+To change this, set the `COLUMNS` environment variable.
+
+```yaml
+      - uses: julia-actions/julia-docdeploy@v1
+        env:
+          COLUMNS: '200'
+```


### PR DESCRIPTION
This took me a while to figure out, so better to document it. Without overriding the width, it is hard to run doctests where the output shouldn't be wrapped such as for PrettyTables.jl output.

I've also tried setting the prefix to
```
DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24'
```
or manually adding that prefix, but that both didn't work.

Setting the COLUMNS environment variable did work. Tested on a `windows-latest` and `ubuntu-latest` runner.