### PR TITLE
Simplify the key setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ on:
 
 jobs:
   Documenter:
+    permissions: write-all
     name: Documentation
     runs-on: ubuntu-latest
     steps:
@@ -19,13 +20,6 @@ jobs:
       - uses: julia-actions/julia-docdeploy@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-```
-
-You need `DOCUMENTER_KEY` for deployement, which you can generate using DocumenterTools:
-```
-julia> using DocumenterTools, YourPackage
-julia> DocumenterTools.genkeys(YourPackage)
 ```
 
 If you need to build your documentation on a particular Julia version, you can insert

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ on:
 
 jobs:
   Documenter:
-    permissions: write-all
+    permissions:
+      contents: write
     name: Documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Manually adding a separate `DOCUMENTER_KEY` shouldn't be necessary. See https://github.com/JuliaDocs/Documenter.jl/pull/1819 for more info.