### PR TITLE
Update use of `inputs.install-package` variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
         # Run the Julia command
         "${julia_cmd[@]}"
       shell: bash
-      if: ${{ inputs.install-package }}
+      if: ${{ inputs.install-package == 'true'}}
     - run: |
         # The Julia command that will be executed
         julia_cmd=( julia --color=yes --project=docs/ -e '


### PR DESCRIPTION
Setting 
```
      - uses: julia-actions/julia-docdeploy@v1
        with:
          install-package: false
```
as in the docs doesn't actually cause the relevant run step to be skipped in https://github.com/julia-actions/julia-docdeploy/blob/80c0bdcd0ea677beb566454f5290c4f803b59b64/action.yml#L39

I suspect this is related to https://github.com/actions/runner/issues/1483, hence the proposed change.