### PR TITLE
Disable fancy GHA logging

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,8 @@ runs:
             @eval Module() begin
                 push!(LOAD_PATH, "@docs-logger-env") # access GitHubActions.jl
                 import Logging, GitHubActions
-                Logging.global_logger(GitHubActions.GitHubActionsLogger())
+                # Disable for now, due to https://github.com/julia-actions/julia-docdeploy/issues/31
+                # Logging.global_logger(GitHubActions.GitHubActionsLogger())
                 pop!(LOAD_PATH)
             end
             include("docs/make.jl")' )


### PR DESCRIPTION
as an immediate fix for https://github.com/julia-actions/julia-docdeploy/issues/31

I suspect (but do not know for sure) that https://github.com/JuliaDocs/MarkdownAST.jl/pull/19 would fix the underlying issue. But IMO it is better to try to immediately fix it on our end since it is very bad if doc builds don't finish. Then if that linked PR is merged we can try to re-enable this.