### PR TITLE
Update README.md to suggest installing julia and julia-actions/cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.10'                      # replace this with whatever version you need
+          show-versioninfo: true               # this causes versioninfo to be printed to the action log
       - uses: julia-actions/julia-buildpkg@v1  # if package requires Pkg.build()
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
-
-If you need to build your documentation on a particular Julia version, you can insert
-
-```yaml
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: nightly               # replace this with whatever version you need
-          show-versioninfo: true         # this causes versioninfo to be printed to the action log
-```
-
-as the first entry after `steps:`.
 
 ### Prefixing the Julia command
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.10'                      # replace this with whatever version you need
+          version: '1'                         # replace this with whatever version you need
           show-versioninfo: true               # this causes versioninfo to be printed to the action log
       - uses: julia-actions/julia-buildpkg@v1  # if package requires Pkg.build()
       - uses: julia-actions/julia-docdeploy@v1

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ jobs:
         with:
           version: '1'                         # replace this with whatever version you need
           show-versioninfo: true               # this causes versioninfo to be printed to the action log
+      - uses: julia-actions/cache@v2              # cache using https://github.com/julia-actions/cache
       - uses: julia-actions/julia-buildpkg@v1  # if package requires Pkg.build()
       - uses: julia-actions/julia-docdeploy@v1
         env:


### PR DESCRIPTION
rather than relying on whatever version is on the hosted runners, since:

(1) it may change unexpectedly which could break docs builds
(2) it could be removed as happened for macos

cc @giordano 